### PR TITLE
Add spy mechanics and auto room codes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Pouf Social Game</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div id="login">
+  <h1>Pouf Social Game</h1>
+  <input id="nickname" placeholder="Nickname">
+  <input id="room" placeholder="Room Code (join only)">
+  <button id="create">Create Room</button>
+  <button id="join">Join Room</button>
+</div>
+<div id="game" style="display:none;">
+  <h2 id="roomTitle"></h2>
+  <div id="roomCode"></div>
+  <div id="players"></div>
+  <div id="tokens"></div>
+  <div id="chat"></div>
+  <input id="msg">
+  <select id="target"></select>
+  <button id="send">Send</button>
+  <button id="startBtn" style="display:none;">Start Game</button>
+  <h3>Trade</h3>
+  <select id="tradeTarget"></select>
+  <input id="tradeAmount" type="number" value="1" min="1">
+  <button id="tradeBtn">Propose Trade</button>
+  <h3>Spy</h3>
+  <select id="spyTarget"></select>
+  <button id="spyBtn">Spy on Player</button>
+  <div id="spy" style="display:none;">
+    <h3>Spy Panel</h3>
+    <div id="spyLog"></div>
+  </div>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,134 @@
+let playerId, roomCode;
+let eventSource;
+let tokens = 5;
+
+function el(id){return document.getElementById(id);}
+el("create").onclick = async () => {
+  const nickname = el("nickname").value.trim();
+  if(!nickname) return alert("Enter nickname");
+  const resp = await fetch("/create-room",{method:"POST",body:JSON.stringify({nickname})});
+  const data = await resp.json();
+  if(data.error) return alert(data.error);
+  playerId=data.playerId;
+  roomCode=data.code;
+  startGame(true);
+};
+
+el("join").onclick = async () => {
+  const nickname = el("nickname").value.trim();
+  roomCode = el("room").value.trim();
+  if(!nickname || !roomCode) return alert("Enter nickname and room");
+  const resp = await fetch("/join-room",{method:"POST",body:JSON.stringify({code:roomCode,nickname})});
+  const data = await resp.json();
+  if(data.error) return alert(data.error);
+  playerId=data.playerId;
+  startGame(false);
+};
+
+
+async function startGame(isHost=false){
+  el('login').style.display='none';
+  el('game').style.display='block';
+  el('roomTitle').innerText='Room '+roomCode;
+  el('roomCode').innerText='Code: '+roomCode;
+  if(isHost) el('startBtn').style.display='inline';
+  el('tokens').textContent='Tokens: '+tokens;
+  connectEvents();
+  updatePlayers();
+}
+
+function connectEvents(){
+  eventSource = new EventSource('/events?code='+roomCode+'&playerId='+playerId);
+  eventSource.onmessage = e => {
+    console.log('msg', e.data);
+  };
+  eventSource.addEventListener('player-joined', e => {
+    const data = JSON.parse(e.data);
+    addPlayer(data.id, data.nickname);
+  });
+  eventSource.addEventListener('chat-message', e => addChat(JSON.parse(e.data)));
+  eventSource.addEventListener('private-message', e => handlePrivate(JSON.parse(e.data)));
+  eventSource.addEventListener('trade-request', e => handleTradeRequest(JSON.parse(e.data)));
+  eventSource.addEventListener('trade-result', e => addChat({from:'system', text:`Trade between ${e.data.from} and ${e.data.to} ${e.data.accept?'accepted':'declined'}` }));
+  eventSource.addEventListener('game-start', e => handleGameStart(JSON.parse(e.data)));
+  eventSource.addEventListener('token-update', e => handleToken(JSON.parse(e.data)));
+}
+
+function addChat(msg){
+  const div=document.createElement('div');
+  div.textContent=`${msg.from}: ${msg.text}`;
+  el('chat').appendChild(div);
+}
+
+function handlePrivate(msg){
+  if(msg.to===playerId || msg.from===playerId || msg.intercept){
+    addChat(msg);
+  }
+  if(isSpy || msg.intercept){
+    const div=document.createElement('div');
+    div.textContent=`[SPY] ${msg.from}->${msg.to}: ${msg.text}`;
+    el('spyLog').appendChild(div);
+  }
+}
+
+function handleToken(data){
+  if(data.id===playerId){
+    tokens=data.tokens;
+    el('tokens').textContent='Tokens: '+tokens;
+  }
+}
+
+el('send').onclick = async () => {
+  const text=el('msg').value;
+  const target=el('target').value||null;
+  await fetch('/send-message',{method:'POST',body:JSON.stringify({code:roomCode,playerId,target,text})});
+  el('msg').value='';
+};
+
+el('startBtn').onclick = async () => {
+  await fetch('/start-game',{method:'POST',body:JSON.stringify({code:roomCode,playerId})});
+};
+
+el('spyBtn').onclick = async () => {
+  const target=el('spyTarget').value;
+  if(!target) return;
+  await fetch('/spy',{method:'POST',body:JSON.stringify({code:roomCode,playerId,target})});
+};
+
+el('tradeBtn').onclick = async () => {
+  const target=el('tradeTarget').value;
+  const amount=parseInt(el('tradeAmount').value)||1;
+  await fetch('/trade',{method:'POST',body:JSON.stringify({code:roomCode,playerId,target,amount})});
+};
+
+function handleTradeRequest(data){
+  if(data.to!==playerId) return;
+  if(confirm(`Accept ${data.amount} token from ${data.from}?`)){
+    fetch('/trade-response',{method:'POST',body:JSON.stringify({code:roomCode,playerId,from:data.from,accept:true})});
+  } else {
+    fetch('/trade-response',{method:'POST',body:JSON.stringify({code:roomCode,playerId,from:data.from,accept:false})});
+  }
+}
+
+let isSpy=false;
+function handleGameStart(data){
+  if(data.spy===playerId){
+    isSpy=true;
+    el('spy').style.display='block';
+  }
+}
+
+function addPlayer(id,nick){
+  const option=document.createElement('option');
+  option.value=id; option.textContent=nick; el('target').appendChild(option);
+  const option2=option.cloneNode(true); el('tradeTarget').appendChild(option2);
+  const option3=option.cloneNode(true); el('spyTarget').appendChild(option3);
+}
+
+function updatePlayers(){
+  fetch('/players?code='+roomCode)
+    .then(r=>r.json())
+    .then(data=>{
+      data.players.forEach(p=>addPlayer(p.id,p.nickname));
+    });
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; }
+#chat { border: 1px solid #ccc; height: 200px; overflow-y: scroll; margin: 10px 0; padding: 5px; }
+#spyLog { border: 1px solid red; height: 150px; overflow-y: scroll; }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,185 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const rooms = {};
+
+function serveStatic(req, res) {
+  const filePath = path.join(__dirname, req.url === '/' ? '/public/index.html' : req.url);
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      return res.end('Not found');
+    }
+    const ext = path.extname(filePath);
+    const type = {
+      '.html': 'text/html',
+      '.js': 'text/javascript',
+      '.css': 'text/css'
+    }[ext] || 'text/plain';
+    res.writeHead(200, {'Content-Type': type});
+    res.end(data);
+  });
+}
+
+function createRoom(code) {
+  if (!rooms[code]) {
+    rooms[code] = {
+      players: {},
+      started: false,
+      host: null,
+      spy: null,
+      watchers: {}
+    };
+  }
+}
+
+function sendJson(res, obj) {
+  res.writeHead(200, {'Content-Type': 'application/json'});
+  res.end(JSON.stringify(obj));
+}
+
+function sendTokenUpdate(room, id) {
+  const p = room.players[id];
+  if (p && p.res) {
+    const payload = `event: token-update\ndata: ${JSON.stringify({id, tokens: p.tokens})}\n\n`;
+    p.res.write(payload);
+  }
+}
+
+function handlePost(req, res, body) {
+  const parsed = url.parse(req.url, true);
+  if (parsed.pathname === '/create-room') {
+    const {nickname} = JSON.parse(body);
+    let code;
+    do {
+      code = Math.floor(10000 + Math.random()*90000).toString();
+    } while (rooms[code]);
+    createRoom(code);
+    const room = rooms[code];
+    const playerId = Date.now().toString() + Math.random();
+    room.players[playerId] = {id: playerId, nickname, tokens: 5, res: null};
+    room.host = playerId;
+    sendJson(res, {playerId, code});
+  } else if (parsed.pathname === '/join-room') {
+    const {code, nickname} = JSON.parse(body);
+    const room = rooms[code];
+    if (!room) return sendJson(res, {error: 'Room not found'});
+    const playerId = Date.now().toString() + Math.random();
+    room.players[playerId] = {id: playerId, nickname, tokens: 5, res: null};
+    broadcast(room, 'player-joined', {id: playerId, nickname});
+    sendJson(res, {playerId});
+  } else if (parsed.pathname === '/start-game') {
+    const {code, playerId} = JSON.parse(body);
+    const room = rooms[code];
+    if (!room || room.host !== playerId) return sendJson(res, {error: 'Not host'});
+    if (room.started) return sendJson(res, {error: 'Already started'});
+    const ids = Object.keys(room.players);
+    const spy = ids[Math.floor(Math.random() * ids.length)];
+    room.spy = spy;
+    room.started = true;
+    broadcast(room, 'game-start', {spy});
+    ids.forEach(id => sendTokenUpdate(room, id));
+    sendJson(res, {ok: true});
+  } else if (parsed.pathname === '/send-message') {
+    const {code, playerId, target, text} = JSON.parse(body);
+    const room = rooms[code];
+    if (!room) return sendJson(res, {error: 'Room not found'});
+    const player = room.players[playerId];
+    if (!player) return sendJson(res, {error: 'Bad player'});
+    const msg = {from: playerId, text, to: target};
+    if (target) {
+      const watchers = (room.watchers[playerId] || []).filter(w => w.expire > Date.now());
+      room.watchers[playerId] = watchers;
+      const ids = [target, playerId, room.spy, ...watchers.map(w=>w.id)];
+      const msgWithFlag = watchers.length ? {...msg, intercept:true} : msg;
+      broadcast(room, 'private-message', msgWithFlag, ids);
+    } else {
+      broadcast(room, 'chat-message', msg);
+    }
+    sendJson(res, {ok: true});
+  } else if (parsed.pathname === '/trade') {
+    const {code, playerId, target, amount} = JSON.parse(body);
+    const room = rooms[code];
+    if (!room) return sendJson(res, {error: 'Room not found'});
+    const player = room.players[playerId];
+    const tgt = room.players[target];
+    if (!player || !tgt) return sendJson(res, {error: 'Bad player'});
+    if (player.tokens < amount) return sendJson(res, {error: 'Not enough tokens'});
+    const trade = {from: playerId, to: target, amount};
+    broadcast(room, 'trade-request', trade, [target]);
+    sendJson(res, {ok: true});
+  } else if (parsed.pathname === '/trade-response') {
+    const {code, playerId, from, accept} = JSON.parse(body);
+    const room = rooms[code];
+    const giver = room.players[from];
+    const receiver = room.players[playerId];
+    if (!room || !giver || !receiver) return sendJson(res, {error: 'Bad player'});
+    if (accept) {
+      if (giver.tokens > 0) {
+        giver.tokens -= 1;
+        receiver.tokens += 1;
+      }
+    }
+    broadcast(room, 'trade-result', {from, to: playerId, accept});
+    sendTokenUpdate(room, from);
+    sendTokenUpdate(room, playerId);
+    sendJson(res, {ok: true});
+  } else if (parsed.pathname === '/spy') {
+    const {code, playerId, target} = JSON.parse(body);
+    const room = rooms[code];
+    const player = room && room.players[playerId];
+    if (!room || !player || !room.players[target]) return sendJson(res, {error:'Bad player'});
+    if (player.tokens <=0) return sendJson(res,{error:'No tokens'});
+    player.tokens -=1;
+    room.watchers[target] = room.watchers[target] || [];
+    room.watchers[target].push({id: playerId, expire: Date.now()+30000});
+    sendTokenUpdate(room, playerId);
+    sendJson(res,{ok:true});
+  } else {
+    res.writeHead(404); res.end();
+  }
+}
+
+function broadcast(room, event, data, targets) {
+  const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  const ids = Array.from(new Set(targets || Object.keys(room.players)));
+  ids.forEach(id => {
+    const p = room.players[id];
+    if (p && p.res) {
+      p.res.write(payload);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const parsed = url.parse(req.url, true);
+  if (req.method === 'GET' && (parsed.pathname === '/' || parsed.pathname.startsWith('/public'))) {
+    serveStatic(req, res);
+  } else if (req.method === 'GET' && parsed.pathname === '/players') {
+    const { code } = parsed.query;
+    const room = rooms[code];
+    if (!room) { res.writeHead(404); return res.end(); }
+    const list = Object.values(room.players).map(p => ({id:p.id, nickname:p.nickname}));
+    return sendJson(res, {players: list});
+  } else if (req.method === 'GET' && parsed.pathname === '/events') {
+    const {code, playerId} = parsed.query;
+    const room = rooms[code];
+    if (!room || !room.players[playerId]) {
+      res.writeHead(404); return res.end();
+    }
+    res.writeHead(200, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection':'keep-alive'});
+    room.players[playerId].res = res;
+    res.write('\n');
+    sendTokenUpdate(room, playerId);
+  } else if (req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => handlePost(req, res, body));
+  } else {
+    res.writeHead(404); res.end();
+  }
+});
+
+server.listen(3000, () => console.log('Server running on http://localhost:3000'));


### PR DESCRIPTION
## Summary
- auto-generate five digit room codes on creation
- allow host to start the game and display room code
- implement spying with token costs and timed interception
- show and update tokens on the client

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_b_683c765be99c832fb37127619f772126